### PR TITLE
各種S3互換実装に対応するためのオプション追加

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -11,7 +11,7 @@ services:
       db:
         condition: service_healthy
     ports:
-      - "8020:8020"
+      - "8000:8000"
     env_file:
       - .env
 


### PR DESCRIPTION
# 詳細

#1 参照

# 動作確認方法

## 環境変数の設定方法
concurrent-webのS3で動作しているオプションをそのまま
 `region` を除いて環境変数( `.env` ) に設定することで動作する。


## 手元でデバッグする場合
`$dummy_ccid` は IdentityGeneratorを用いて生成(実態がなくても良い)
`$some_file` は quotaの容量を超えない適当なメディアファイルへのパス

```shell
docker compose up -d --build
curl -vH 'cc-user-id:{$dummy_ccid}' -X POST localhost:8000/files -F "file={$some_file}"
```

## Concurrentとの結合テストをする場合
`mediaserver` として`ghcr.io/fono09/cc-media-server:v0.0.1` を用い、
メディアの設定を `domain` として動作確認する。 